### PR TITLE
Add API request logging subscriber

### DIFF
--- a/TestJwt.http
+++ b/TestJwt.http
@@ -1,5 +1,5 @@
-﻿POST http://localhost/api/login HTTP/1.1
-Host: your-domain.com
+﻿### Authentification (récupération du token)
+POST http://localhost/api/login
 Content-Type: application/json
 X-API-TOKEN: LeSuperToken123
 
@@ -7,3 +7,12 @@ X-API-TOKEN: LeSuperToken123
     "username": "test",
     "password": "password123"
 }
+
+> {% client.global.set("auth_token", response.body.token); %}
+
+###
+
+### Requête protégée avec le token récupéré
+GET http://localhost/api/jwt/comments
+Authorization: Bearer {{auth_token}}
+X-API-TOKEN: LeSuperToken123

--- a/src/Controller/CommentController.php
+++ b/src/Controller/CommentController.php
@@ -22,7 +22,7 @@ final class CommentController extends AbstractController
     #[OA\Get(
         description: 'Retourne tous les commentaires.',
         summary: 'Liste des commentaires',
-        security: [['bearer' => []]],
+        security: ['bearer' => [], 'apiKey' => []],
         responses: [
             new OA\Response(
                 response: 200,
@@ -60,6 +60,7 @@ final class CommentController extends AbstractController
 
         return $this->json($data);
     }
+
 
     #[Route('', name: 'create', methods: ['POST'])]
     #[OA\Post(

--- a/src/Controller/DatabaseTestController.php
+++ b/src/Controller/DatabaseTestController.php
@@ -51,7 +51,7 @@ class DatabaseTestController extends AbstractController
         path: '/api/jwt/GetDataToken',
         description: 'Retrieve the JWT data token.',
         summary: 'Get JWT Token Data',
-        security: [['bearer' => []]],
+        security: ['bearer' => [],'apiKey' => []],
         tags: ['JWT']
     )]
     #[OA\Response(

--- a/src/EventSubscriber/ApiLoggerSubscriber.php
+++ b/src/EventSubscriber/ApiLoggerSubscriber.php
@@ -1,0 +1,48 @@
+<?php
+// src/EventSubscriber/ApiLoggerSubscriber.php
+namespace App\EventSubscriber;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class ApiLoggerSubscriber implements EventSubscriberInterface
+{
+    private LoggerInterface $logger;
+
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => 'onRequest',
+        ];
+    }
+
+    public function onRequest(RequestEvent $event): void
+    {
+        $request = $event->getRequest();
+        $path = $request->getPathInfo();
+
+        if (str_starts_with($path, '/api')) {
+            $this->logger->info('Appel API', [
+                'method'      => $request->getMethod(),
+                'path'        => $path,
+                'route'       => $request->attributes->get('_route'),
+                'ip'          => $request->getClientIp(),
+                'user'        => $request->getUser() ?? 'anonymous',
+                'query'       => $request->query->all(),
+                'request'     => $request->request->all(),
+                'json'        => json_decode($request->getContent(), true),
+                'headers'     => $request->headers->all(),
+                'user_agent'  => $request->headers->get('User-Agent'),
+                'content_type'=> $request->headers->get('Content-Type'),
+            ]);
+        }
+    }
+
+}


### PR DESCRIPTION
Introduce `ApiLoggerSubscriber` to log details of incoming API requests. This includes method, path, route, user details, query parameters, request body, and headers for better monitoring and debugging. Only requests starting with `/api` are logged.